### PR TITLE
Fixing log error for Midi Input

### DIFF
--- a/src/midi/WebMIDI.js
+++ b/src/midi/WebMIDI.js
@@ -49,7 +49,7 @@ class WebMIDI {
 		}
 		// New port is set
 		this._midiInput.onmidimessage = this.onMIDIMessage.bind(this);
-		console.log("MIDI input selected", this._midiInput.name, this._midiOutput.manufacturer);
+		console.log("MIDI input selected", this._midiInput.name, this._midiInput.manufacturer);
 		if (this._onInputSelected) {
 			this._onInputSelected(this._midiInput);
 		}


### PR DESCRIPTION
Currently there's a small error in a console.log that stops WebMidi.js from working. Fixing the console.log error makes it work again!